### PR TITLE
Updates

### DIFF
--- a/.github/workflows/build_deb.yml
+++ b/.github/workflows/build_deb.yml
@@ -38,7 +38,6 @@ jobs:
         os: [
           { distribution: ubuntu, codename: focal,    description: Ubuntu 20.04 (Focal Fossa),     qt_version: '5' }, # Qt 6 not available
           { distribution: ubuntu, codename: jammy,    description: Ubuntu 22.04 (Jammy Jellyfish), qt_version: '6' },
-          { distribution: ubuntu, codename: mantic,   description: Ubuntu 23.10 (Mantic Minotaur), qt_version: '6' },
           { distribution: ubuntu, codename: noble,    description: Ubuntu 24.04 (Noble Numbat),    qt_version: '6' },
           { distribution: debian, codename: buster,   description: Debian 10.x (Buster),           qt_version: '5' }, # Qt 6 not available
           { distribution: debian, codename: bullseye, description: Debian 11.x (Bullseye),         qt_version: '5' }, # Qt 6 only available from bullseye-backports

--- a/debian/distributions
+++ b/debian/distributions
@@ -16,14 +16,6 @@ SignWith: yes
 
 Origin: Hyperion-Project
 Label: releases.hyperion-project.org
-Codename: mantic
-Architectures: amd64 armhf arm64
-Components: main
-Description: Official APT Repository by Hyperion Project
-SignWith: yes
-
-Origin: Hyperion-Project
-Label: releases.hyperion-project.org
 Codename: noble
 Architectures: amd64 armhf arm64
 Components: main

--- a/install.sh
+++ b/install.sh
@@ -106,8 +106,8 @@ function get_architecture() {
 	echo "${CURRENT_ARCHITECTURE}"
 }
 
-function get_package_architecture() {
-	# translate the architecture in the package naming architecture
+function get_github_artifacts_architecture() {
+	# translate the architecture in the one used for artifacts build via GitHub
 	architecture=$(get_architecture)
 	case "$architecture" in
 	armhf)
@@ -204,7 +204,6 @@ function install_deb_package() {
 		suites=${_CODEBASE}
 	fi
 
-	architectures=$(get_package_architecture)
 	DEB822="X-Repolib Name: Hyperion
 Enabled: yes
 Types: deb
@@ -306,7 +305,7 @@ if [ -z "${latestRelease}" ]; then
 fi
 info "Latest GibHub release identified: ${latestRelease}"
 
-architecture=$(get_package_architecture)
+architecture=$(get_github_artifacts_architecture)
 
 suffix='tar.gz'
 download_url=$(echo "$releaseResponse" | tr '\r\n' ' ' | ${_PYTONCMD} -c """


### PR DESCRIPTION
- Remove Ubuntu Mantic as EoL
- easy install script: Clarify get_package_architecture is for Git-Builds  only